### PR TITLE
Battery stuff, MII Maker stuff removal and applets

### DIFF
--- a/src/input/Input.h
+++ b/src/input/Input.h
@@ -48,11 +48,13 @@ public:
         uint32_t buttons_h;
         uint32_t buttons_d;
         uint32_t buttons_r;
+        uint8_t battery;
         bool validPointer;
         bool touched;
         float pointerAngle;
         int32_t x;
         int32_t y;
+
     } PadData;
 
     PadData data{};

--- a/src/input/VPADInput.h
+++ b/src/input/VPADInput.h
@@ -23,7 +23,7 @@ class VPadInput : public Input {
 public:
     //!Constructor
     VPadInput() {
-        memset(&vpad, 0, sizeof(vpad));
+        memset(&vpad, 0, sizeof(vpad));     
     }
 
     //!Destructor
@@ -41,6 +41,8 @@ public:
             data.buttons_d    = vpad.trigger;
             data.validPointer = !vpad.tpNormal.validity;
             data.touched      = vpad.tpNormal.touched;
+            data.battery      = vpad.battery;
+            headphones        = vpad.usingHeadphones ? 1 : 0;
 
             VPADGetTPCalibratedPoint(VPAD_CHAN_0, &tpCalib, &vpad.tpFiltered1);
 
@@ -55,7 +57,10 @@ public:
         return false;
     }
 
+    bool headphones;
+
 private:
     VPADStatus vpad{};
     VPADTouchData tpCalib{};
+    PadData lastData{};
 };

--- a/src/input/WPADInput.h
+++ b/src/input/WPADInput.h
@@ -133,6 +133,7 @@ public:
         }
 
         KPADRead(channel, &kpad, 1);
+        WPADGetInfo(channel, &wpadInfo);
 
         if (kpad.extensionType == WPAD_EXT_CORE || kpad.extensionType == WPAD_EXT_NUNCHUK) {
             data.buttons_r = remapWiiMoteButtons(kpad.release);

--- a/src/input/WPADInput.h
+++ b/src/input/WPADInput.h
@@ -144,6 +144,8 @@ public:
             data.buttons_d = remapClassicButtons(kpad.classic.trigger);
         }
 
+        data.battery = wpadInfo.batteryLevel;
+
         data.validPointer = (kpad.posValid == 1 || kpad.posValid == 2) &&
                             (kpad.pos.x >= -1.0f && kpad.pos.x <= 1.0f) &&
                             (kpad.pos.y >= -1.0f && kpad.pos.y <= 1.0f);
@@ -173,5 +175,6 @@ public:
 
 private:
     KPADStatus kpad{};
+    WPADInfo wpadInfo{};
     KPADChan channel;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,8 +46,8 @@ static bool right_scrolling = false;
 static bool up_scrolling = false;
 static bool down_scrolling = false;
 static bool game_launched = false;
-bool quit = false;
 bool menuOpen = false;
+int battery_level = 0.0;
 
 int seperation_space = 264;
 int target_camera_offset_x = 0;
@@ -114,15 +114,8 @@ SDL_Texture* load_texture(const char* path, SDL_Renderer* renderer) {
     return texture;
 }
 
-inline bool RunningFromMiiMaker() {
-    return (OSGetTitleID() & 0xFFFFFFFFFFFFF0FFull) == 0x000500101004A000ull;
-}
-
 void launch_title_if_exists(uint64_t titleID) {
-    if (RunningFromMiiMaker()) {
-        printf("Cannot launch system titles from Mii Maker environment.\n");
-        quit = true;
-    } else if (SYSCheckTitleExists(titleID)) {
+    if (SYSCheckTitleExists(titleID)) {
         SYSLaunchTitle(titleID);
     } else {
         printf("Title not found.\n");
@@ -275,10 +268,11 @@ void shutdown() {
 
     RPXLoader_DeInitLibrary();
 
+    AXQuit();
+
     SDL_DestroyWindow(main_window);
     SDL_DestroyRenderer(main_renderer);
     SDL_Quit();
-    AXQuit();
 }
 
 void input(Input &input) {
@@ -452,10 +446,6 @@ void input(Input &input) {
         int max_camera_offset = seperation_space * 24 - WINDOW_WIDTH;
         if (target_camera_offset_x > max_camera_offset) target_camera_offset_x = max_camera_offset;
     }
-
-    if (event.type == SDL_QUIT) {
-        quit = true;
-    }
 }
 
 void update() {
@@ -611,7 +601,7 @@ void update() {
         std::string title = std::string(ACCOUNT_ID) + "'s Page";
         // render title
     } else {
-        char batteryStr[32];
+        std::string battery = std::to_string(battery_level) + "%";
         // render the battery life
     }
 
@@ -673,18 +663,9 @@ int main(int argc, char const *argv[]) {
             }
         }
         baseInput.process();
+        battery_level = vpadInput.data.battery / 255 * 100;
 
         input(baseInput);
-
-        if (quit) {
-           if (RunningFromMiiMaker()) {
-                // Legacy way, just quit
-                break;
-            } else {
-                // Launch menu otherwise
-                SYSLaunchMenu();
-            }
-        }
 
         update();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -393,15 +393,20 @@ void input(Input &input) {
                 }
             }
         } else {
-            if (cur_selected_tile == 1) {
+            if (cur_selected_tile == 0) {
+                printf("Launching MiiVerse !\n");
+                _SYSSwitchTo(SysAppPFID::SYSAPP_PFID_MIIVERSE);
+            } else if (cur_selected_tile == 1) {
                 const char* launch_path = "wiiu/apps/appstore/appstore.wuhb";
 
                 RPXLoaderStatus st = RPXLoader_LaunchHomebrew(launch_path);
                 printf("Launch status: %s\n", RPXLoader_GetStatusStr(st));
             } else if (cur_selected_tile == 3) {
-                uint64_t title_id = 0x000500301001210AULL;
-                printf("Title check: %s\n", SYSCheckTitleExists(title_id) ? "found" : "not found");
-                launch_title_if_exists(title_id);
+                printf("Launching the Browser !\n");
+                SYSSwitchToBrowser(nullptr);
+            } else if (cur_selected_tile == 5) {
+                printf("Launching Download Manager !\n");
+                _SYSSwitchTo(SysAppPFID::SYSAPP_PFID_DOWNLOAD_MANAGEMENT);
             } else if (cur_selected_tile == 6) {
                 cur_menu = MENU_SETTINGS;
             }


### PR DESCRIPTION
Battery level can now be read for any connected controller, I replaced the char battery[32] with the battery percentage of the DRC as an str. The MII Code really isn't necessary because it's already not required for most legacy apps + the chance that this is runned from MII Maker are very slim because it's a menu replacement